### PR TITLE
Fixed typographical error, changed arbitarily to arbitrarily in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Interrotron.run('(> #t{2010-09-04} start_date)', start_date: DateTime.parse('201
 Interrotron.run('(> (now) (ago (hours 12)))')
 # => true
 
-# You can, of course, create arbitarily complex exprs
+# You can, of course, create arbitrarily complex exprs
 Interrotron.run("(if false
                      (+ 4 -3)
                      (- 10 (+ 2 (+ 1 1))))")


### PR DESCRIPTION
@andrewvc, I've corrected a typographical error in the documentation of the [interrotron](https://github.com/andrewvc/interrotron) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
